### PR TITLE
Implement struct declaration parser

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -76,7 +76,7 @@
           "kind": "bin"
         }
       },
-      "args": ["examples/struct.rc", "--ast"],
+      "args": ["examples/struct.rc"],
       "cwd": "${workspaceFolder}"
     },
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,197 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug unit tests in library 'stdlib'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--lib",
+          "--package=stdlib"
+        ],
+        "filter": {
+          "name": "stdlib",
+          "kind": "lib"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug unit tests in library 'rocklang'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--lib",
+          "--package=rocklang"
+        ],
+        "filter": {
+          "name": "rocklang",
+          "kind": "lib"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug executable 'rocklang'",
+      "cargo": {
+        "args": [
+          "build",
+          "--bin=rocklang",
+          "--package=rocklang"
+        ],
+        "filter": {
+          "name": "rocklang",
+          "kind": "bin"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug executable 'rocklang' ast test rc",
+      "cargo": {
+        "args": [
+          "build",
+          "--bin=rocklang",
+          "--package=rocklang"
+        ],
+        "filter": {
+          "name": "rocklang",
+          "kind": "bin"
+        }
+      },
+      "args": ["examples/struct.rc", "--ast"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug unit tests in executable 'rocklang'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--bin=rocklang",
+          "--package=rocklang"
+        ],
+        "filter": {
+          "name": "rocklang",
+          "kind": "bin"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug integration test 'tokenizer_tests'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--test=tokenizer_tests",
+          "--package=rocklang"
+        ],
+        "filter": {
+          "name": "tokenizer_tests",
+          "kind": "test"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug integration test 'parser_tests'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--test=parser_tests",
+          "--package=rocklang"
+        ],
+        "filter": {
+          "name": "parser_tests",
+          "kind": "test"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug integration test 'token_test'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--test=token_test",
+          "--package=rocklang"
+        ],
+        "filter": {
+          "name": "token_test",
+          "kind": "test"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug integration test 'compiler_tests'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--test=compiler_tests",
+          "--package=rocklang"
+        ],
+        "filter": {
+          "name": "compiler_tests",
+          "kind": "test"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug integration test 'integration_tests'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--test=integration_tests",
+          "--package=rocklang"
+        ],
+        "filter": {
+          "name": "integration_tests",
+          "kind": "test"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    }
+  ]
+}

--- a/examples/struct.rc
+++ b/examples/struct.rc
@@ -1,0 +1,3 @@
+struct user {
+  name: String
+}

--- a/examples/struct.rc
+++ b/examples/struct.rc
@@ -1,4 +1,0 @@
-struct User {
-  name: string
-  age: number
-}

--- a/examples/struct.rc
+++ b/examples/struct.rc
@@ -1,8 +1,4 @@
-struct user {
+struct User {
   name: string
   age: number
-}
-
-struct admin_panel {
-  user: user
 }

--- a/examples/struct.rc
+++ b/examples/struct.rc
@@ -1,3 +1,8 @@
 struct user {
-  name: String
+  name: string
+  age: number
+}
+
+struct admin_panel {
+  user: user
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -682,6 +682,13 @@ impl Visitor<Value> for Compiler {
             return_type: extern_stmt.return_type,
         }
     }
+
+    fn visit_struct(&mut self, _name: &expression::Struct) -> Value {
+        // let struct_type = self.context.struct_type(&name.name);
+        // let struct_value = self.context.const_named_struct(struct_type, &name.fields);
+
+        Value::Null
+    }
 }
 
 impl Compile for Compiler {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -692,9 +692,7 @@ impl Visitor<Value> for Compiler {
 
         let struct_type = self.context.struct_type(&types, false);
 
-        Value::Struct {
-            typ: struct_type
-        }
+        Value::Struct { typ: struct_type }
     }
 }
 
@@ -743,7 +741,7 @@ impl Compiler {
         if self.get_var(literal).is_none() && self.stack.len() <= 1 {
             let ptr = match val {
                 Value::Null => unreachable!(),
-                Value::Struct{ typ } => unreachable!(),
+                Value::Struct { typ: _ } => unreachable!(),
                 Value::Numeric(_)
                 | Value::Ptr(_)
                 | Value::String(_)
@@ -762,7 +760,7 @@ impl Compiler {
                     ptr.set_initializer(self.context.const_double(0.0));
                 }
                 Value::Null => unreachable!(),
-                Value::Struct{ typ } => unreachable!(),
+                Value::Struct { typ: _ } => unreachable!(),
                 Value::String(_) => todo!(),
                 Value::Function { .. } => (),
                 Value::Break => unreachable!(),
@@ -773,7 +771,7 @@ impl Compiler {
 
             let var = match val {
                 Value::Numeric(_) => Var::Numeric(ptr),
-                Value::Struct { typ } => todo!(),
+                Value::Struct { typ: _ } => todo!(),
                 Value::Ptr(_) => Var::Ptr(ptr),
                 Value::Null => Var::Null,
                 Value::String(_) => Var::String(ptr),
@@ -813,7 +811,7 @@ impl Compiler {
 
             let var = match val {
                 Value::Numeric(_) => Var::Numeric(ptr),
-                Value::Struct { typ } => todo!(),
+                Value::Struct { typ: _ } => todo!(),
                 Value::Ptr(_) => Var::Ptr(ptr),
                 Value::Null => Var::Null,
                 Value::String(_) => Var::String(ptr),

--- a/src/compiler/value.rs
+++ b/src/compiler/value.rs
@@ -13,6 +13,9 @@ pub enum Value {
         typ: llvm::Type,
         return_type: parser::Type,
     },
+    Struct {
+        typ: llvm::Type,
+    },
     Vec(llvm::Value),
     Break,
     Ptr(llvm::Value),

--- a/src/compiler/var.rs
+++ b/src/compiler/var.rs
@@ -10,6 +10,9 @@ pub enum Var {
     Vec(llvm::Value),
     GlobalString(llvm::Value),
     Bool(llvm::Value),
+    Struct {
+        typ: llvm::Type
+    },
     Function {
         val: llvm::Value,
         typ: llvm::Type,

--- a/src/compiler/var.rs
+++ b/src/compiler/var.rs
@@ -11,7 +11,7 @@ pub enum Var {
     GlobalString(llvm::Value),
     Bool(llvm::Value),
     Struct {
-        typ: llvm::Type
+        typ: llvm::Type,
     },
     Function {
         val: llvm::Value,

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,5 +1,5 @@
-use crate::parser::{Param, StructField};
 use crate::parser::Type;
+use crate::parser::{Param, StructField};
 use serde::Serialize;
 
 #[derive(Serialize, Debug, Clone)]
@@ -92,5 +92,5 @@ pub enum Expression {
     FuncDecl(FuncDecl),
     Load(String),
     Extern(Extern),
-    Struct(Struct)
+    Struct(Struct),
 }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,4 +1,4 @@
-use crate::parser::Param;
+use crate::parser::{Param, StructField};
 use crate::parser::Type;
 use serde::Serialize;
 
@@ -70,6 +70,12 @@ pub struct Extern {
 }
 
 #[derive(Serialize, Debug, Clone)]
+pub struct Struct {
+    pub fields: Vec<StructField>,
+    pub name: String,
+}
+
+#[derive(Serialize, Debug, Clone)]
 pub enum Expression {
     Break,
     Bool(bool),
@@ -86,4 +92,5 @@ pub enum Expression {
     FuncDecl(FuncDecl),
     Load(String),
     Extern(Extern),
+    Struct(Struct)
 }

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -366,6 +366,17 @@ impl Context {
         })
     }
 
+    pub fn struct_type(&self, field_types: &[Type], is_var_arg: bool) -> Type {
+        let mut args: Vec<*mut llvm::LLVMType> = field_types.iter().map(|t| t.0).collect();
+        Type(unsafe {
+            LLVMStructType(
+                args.as_mut_ptr(),
+                field_types.len().try_into().unwrap(),
+                if is_var_arg { 1 } else { 0 },
+            )
+        })
+    }
+
     pub fn array_type(&self, el_type: Type, el_count: u32) -> Type {
         Type(unsafe { LLVMArrayType(el_type.0, el_count) })
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -386,7 +386,7 @@ impl Parser {
                                 while match self.peek().clone() {
                                     Token::Identifier(ref field_name) => {
                                         self.advance();
-                                        
+
                                         match self.peek() {
                                             Token::Colon => {
                                                 self.advance();
@@ -397,7 +397,8 @@ impl Parser {
 
                                                         fields.push(StructField {
                                                             name: field_name.clone(),
-                                                            field_type: self.type_from_literal(&field_type)?,
+                                                            field_type: self
+                                                                .type_from_literal(field_type)?,
                                                         });
                                                     }
                                                     _ => {
@@ -407,7 +408,7 @@ impl Parser {
                                                         })
                                                     }
                                                 }
-                                            },
+                                            }
                                             _ => {
                                                 return Err(ParserError::SyntaxError {
                                                     token: self.previous().clone(),
@@ -417,12 +418,12 @@ impl Parser {
                                         }
 
                                         true
-                                    },
+                                    }
                                     Token::RCurly => {
                                         self.advance();
                                         false
                                     }
-                                    _ => false
+                                    _ => false,
                                 } {}
 
                                 Ok(Expression::Struct(expression::Struct {

--- a/src/token.rs
+++ b/src/token.rs
@@ -36,6 +36,7 @@ pub enum Token {
     Numeric(f64),
     Load,
     Extern,
+    Struct,
     Eof,
 }
 
@@ -75,6 +76,7 @@ fn token_name(token: &Token) -> &str {
         Token::Colon => "Colon",
         Token::Load => "Load",
         Token::Extern => "Extern",
+        Token::Struct => "Struct",
     }
 }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -192,6 +192,7 @@ impl Tokenizer {
             "else" => self.add_token(Token::Else),
             "load" => self.add_token(Token::Load),
             "extern" => self.add_token(Token::Extern),
+            "struct" => self.add_token(Token::Struct),
             _ => self.add_token(Token::Identifier(literal)),
         };
     }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -19,6 +19,7 @@ pub trait Visitor<T> {
     fn visit_func_decl(&mut self, body: &expression::FuncDecl) -> T;
     fn visit_load(&mut self, name: &str) -> T;
     fn visit_extern(&mut self, name: &expression::Extern) -> T;
+    fn visit_struct(&mut self, name: &expression::Struct) -> T;
 
     fn walk(&mut self, expr: &Expression) -> T {
         match expr {
@@ -37,6 +38,7 @@ pub trait Visitor<T> {
             Expression::FuncDecl(expr) => self.visit_func_decl(expr),
             Expression::Load(expr) => self.visit_load(expr),
             Expression::Extern(expr) => self.visit_extern(expr),
+            Expression::Struct(expr) => self.visit_struct(expr),
         }
     }
 }

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -1586,7 +1586,7 @@ fn it_parses_grouping_expression_with_identifiers() {
 
 #[test]
 fn it_parses_load_expression() {
-    let mut parser = Parser::new(&vec![
+    let mut parser = Parser::new(&[
         Token::Load,
         Token::LeftParen,
         Token::String(String::from("somelib.so")),
@@ -1600,6 +1600,45 @@ fn it_parses_load_expression() {
     assert_json_eq!(
         json!([{
             "Load": "somelib.so"
+        }]),
+        json
+    )
+}
+
+#[test]
+fn it_parse_struct_declaration() {
+    let mut parser = Parser::new(&vec![
+        Token::Struct,
+        Token::Identifier("User".to_string()),
+        Token::LCurly,
+        Token::Identifier("name".to_string()),
+        Token::Colon,
+        Token::Identifier("string".to_string()),
+        Token::Identifier("age".to_string()),
+        Token::Colon,
+        Token::Identifier("number".to_string()),
+        Token::RCurly,
+        Token::Eof,
+    ]);
+
+    let ast = parser.parse().unwrap().body;
+    let json = serde_json::to_value(&ast).unwrap();
+
+    assert_json_eq!(
+        json!([{
+            "Struct": {
+                "name": "User",
+                "fields": [
+                    {
+                        "name": "name",
+                        "field_type": "String"
+                    },
+                    {
+                        "name": "age",
+                        "field_type": "Numeric"
+                    }
+                ]
+            }
         }]),
         json
     )


### PR DESCRIPTION
This is the only implementation for struct declaration. 
Struct declaration will not compile to IR code. 
Only when a reference to the new structure is created, the structure declaration appears in the IR code.

Next step - implement possibility to create struct instance
