### PR TITLE
Remove colon token from function definition and move return type afte…

### DIFF
--- a/examples/mandelbrot.rck
+++ b/examples/mandelbrot.rck
@@ -1,7 +1,7 @@
 WIDTH = 30
 HEIGHT = 30
 
-complexprint = (c: vec): void => {
+complexprint = (c: vec) => void {
 	print(string(vec_get(c, 0)))
 	print("+")
 	print(string(vec_get(c, 1)))
@@ -9,7 +9,7 @@ complexprint = (c: vec): void => {
 	print("\n")
 }
 
-complexadd = (a: vec, b: vec): vec => {
+complexadd = (a: vec, b: vec) => vec {
 	r = vec_get(a, 0) + vec_get(b, 0)
 	img = vec_get(a, 1) + vec_get(b, 1)
 
@@ -21,7 +21,7 @@ complexadd = (a: vec, b: vec): vec => {
 }
 
 
-complexmul = (a: vec, b: vec): vec => {
+complexmul = (a: vec, b: vec) => vec {
 	r = vec_get(a, 0) * vec_get(b, 0) - vec_get(a, 1) * vec_get(b, 1)
 	img = vec_get(a, 0) * vec_get(b, 1) + vec_get(a, 1) * vec_get(b, 0)
 

--- a/examples/sieve.rck
+++ b/examples/sieve.rck
@@ -1,4 +1,4 @@
-mem_set = (vec: vec, val: number, n: number): vec => {
+mem_set = (vec: vec, val: number, n: number) => vec {
 	i = 0
 	while i < n {
 		vec_set(vec, i, val)
@@ -7,7 +7,7 @@ mem_set = (vec: vec, val: number, n: number): vec => {
 	vec
 }
 
-sieve = (n: number): void => {
+sieve = (n: number) => void {
 	v = vec_new()
 	prime = mem_set(v, 1, n + 1)
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -186,7 +186,6 @@ impl Compiler {
             Err(_) => Err(CompilerError::EngineInitError {})?,
         };
         let pass_manager = llvm::PassManager::new(&module);
-
         Ok(Compiler {
             after_loop_blocks: Vec::new(),
             maybe_orphaned: Vec::new(),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -525,7 +525,7 @@ impl Parser {
                 }
 
                 match self.advance().kind {
-                    TokenKind::Colon => (),
+                    TokenKind::Arrow => (),
                     _ => {
                         return Err(ParserError::SyntaxError {
                             token: self.previous().clone(),
@@ -554,15 +554,6 @@ impl Parser {
                     }
                 };
 
-                match self.advance().kind {
-                    TokenKind::Arrow => (),
-                    _ => {
-                        return Err(ParserError::SyntaxError {
-                            token: self.previous().clone(),
-                            backtrace: Backtrace::new(),
-                        })
-                    }
-                }
 
                 match self.advance().kind {
                     TokenKind::LCurly => (),

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -1180,9 +1180,8 @@ fn it_parses_func_declaration_with_no_params() {
     let mut parser = Parser::new(&vec![
         token!(TokenKind::LeftParen),
         token!(TokenKind::RightParen),
-        token!(TokenKind::Colon),
-        token!(TokenKind::Identifier("void".to_string())),
         token!(TokenKind::Arrow),
+        token!(TokenKind::Identifier("void".to_string())),
         token!(TokenKind::LCurly),
         token!(TokenKind::Identifier("print".to_string())),
         token!(TokenKind::LeftParen),
@@ -1257,9 +1256,8 @@ fn it_parses_func_declaration_with_one_number_param() {
         token!(TokenKind::Colon),
         token!(TokenKind::Identifier("number".to_string())),
         token!(TokenKind::RightParen),
-        token!(TokenKind::Colon),
-        token!(TokenKind::Identifier("void".to_string())),
         token!(TokenKind::Arrow),
+        token!(TokenKind::Identifier("void".to_string())),
         token!(TokenKind::LCurly),
         token!(TokenKind::Identifier("print".to_string())),
         token!(TokenKind::LeftParen),
@@ -1339,9 +1337,8 @@ fn it_parses_func_declaration_with_one_vec_param() {
         token!(TokenKind::Colon),
         token!(TokenKind::Identifier("vec".to_string())),
         token!(TokenKind::RightParen),
-        token!(TokenKind::Colon),
-        token!(TokenKind::Identifier("void".to_string())),
         token!(TokenKind::Arrow),
+        token!(TokenKind::Identifier("void".to_string())),
         token!(TokenKind::LCurly),
         token!(TokenKind::Identifier("print".to_string())),
         token!(TokenKind::LeftParen),
@@ -1421,9 +1418,8 @@ fn it_parses_func_declaration_with_one_fun_param() {
         token!(TokenKind::Colon),
         token!(TokenKind::Identifier("fun".to_string())),
         token!(TokenKind::RightParen),
-        token!(TokenKind::Colon),
-        token!(TokenKind::Identifier("void".to_string())),
         token!(TokenKind::Arrow),
+        token!(TokenKind::Identifier("void".to_string())),
         token!(TokenKind::LCurly),
         token!(TokenKind::Identifier("print".to_string())),
         token!(TokenKind::LeftParen),
@@ -1507,9 +1503,8 @@ fn it_parses_func_declaration_with_multiple_params() {
         token!(TokenKind::Colon),
         token!(TokenKind::Identifier("number".to_string())),
         token!(TokenKind::RightParen),
-        token!(TokenKind::Colon),
-        token!(TokenKind::Identifier("void".to_string())),
         token!(TokenKind::Arrow),
+        token!(TokenKind::Identifier("void".to_string())),
         token!(TokenKind::LCurly),
         token!(TokenKind::Identifier("print".to_string())),
         token!(TokenKind::LeftParen),
@@ -1707,41 +1702,6 @@ fn it_returns_an_error_when_func_has_no_arg_type_after_arg_name() {
 }
 
 #[test]
-fn it_returns_an_error_when_func_has_no_return_type() {
-    let mut parser = Parser::new(&vec![
-        token!(TokenKind::LeftParen),
-        token!(TokenKind::Identifier("a".to_string())),
-        token!(TokenKind::Colon),
-        token!(TokenKind::Identifier("fun".to_string())),
-        token!(TokenKind::RightParen),
-        token!(TokenKind::Arrow),
-        token!(TokenKind::LCurly),
-        token!(TokenKind::Identifier("print".to_string())),
-        token!(TokenKind::LeftParen),
-        token!(TokenKind::String("hello".to_string())),
-        token!(TokenKind::RightParen),
-        token!(TokenKind::RCurly),
-        token!(TokenKind::Eof),
-    ]);
-
-    match parser.parse() {
-        Ok(_) => assert!(false, "should return an error"),
-        Err(e) => {
-            assert!(matches!(
-                e,
-                ParserError::SyntaxError {
-                    token: Token {
-                        kind: TokenKind::Arrow,
-                        ..
-                    },
-                    ..
-                },
-            ));
-        }
-    };
-}
-
-#[test]
 fn it_returns_an_error_when_func_has_unknown_return_type() {
     let mut parser = Parser::new(&vec![
         token!(TokenKind::LeftParen),
@@ -1749,9 +1709,8 @@ fn it_returns_an_error_when_func_has_unknown_return_type() {
         token!(TokenKind::Colon),
         token!(TokenKind::Identifier("fun".to_string())),
         token!(TokenKind::RightParen),
-        token!(TokenKind::Colon),
-        token!(TokenKind::Identifier("wrongtype".to_string())),
         token!(TokenKind::Arrow),
+        token!(TokenKind::Identifier("wrongtype".to_string())),
         token!(TokenKind::LCurly),
         token!(TokenKind::Identifier("print".to_string())),
         token!(TokenKind::LeftParen),
@@ -1786,9 +1745,8 @@ fn it_returns_an_error_when_func_has_non_type_expression_as_return_type() {
         token!(TokenKind::Colon),
         token!(TokenKind::Identifier("fun".to_string())),
         token!(TokenKind::RightParen),
-        token!(TokenKind::Colon),
-        token!(TokenKind::String("string".to_string())),
         token!(TokenKind::Arrow),
+        token!(TokenKind::String("string".to_string())),
         token!(TokenKind::LCurly),
         token!(TokenKind::Identifier("print".to_string())),
         token!(TokenKind::LeftParen),
@@ -1823,7 +1781,6 @@ fn it_returns_error_when_func_decl_has_no_arrow() {
         token!(TokenKind::Colon),
         token!(TokenKind::Identifier("fun".to_string())),
         token!(TokenKind::RightParen),
-        token!(TokenKind::Colon),
         token!(TokenKind::Identifier("void".to_string())),
         token!(TokenKind::LCurly),
         token!(TokenKind::Identifier("print".to_string())),
@@ -1841,7 +1798,7 @@ fn it_returns_error_when_func_decl_has_no_arrow() {
                 e,
                 ParserError::SyntaxError {
                     token: Token {
-                        kind: TokenKind::LCurly,
+                        kind: TokenKind::Identifier(_),
                         ..
                     },
                     ..
@@ -1859,9 +1816,8 @@ fn it_returns_error_when_func_decl_has_no_body() {
         token!(TokenKind::Colon),
         token!(TokenKind::Identifier("fun".to_string())),
         token!(TokenKind::RightParen),
-        token!(TokenKind::Colon),
-        token!(TokenKind::Identifier("void".to_string())),
         token!(TokenKind::Arrow),
+        token!(TokenKind::Identifier("void".to_string())),
         token!(TokenKind::String("hello".to_string())),
         token!(TokenKind::Eof),
     ]);


### PR DESCRIPTION
## Proposed Changes

IMO it is not necessary to use arrow before brackets , beter is rust like syntax


![image](https://github.com/jarkonik/rocklang/assets/49495932/1b374ab9-abd9-4aaa-afec-f293f26e7bfd)

 
